### PR TITLE
fix: 게시물 수와 팔로워 수 -> 승인된 팔로잉 및 팔로워 수를 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/moro/app/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/moro/app/follow/repository/FollowRepository.java
@@ -23,8 +23,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Page<Follow> findByFollowerIdAndStatus(Long followerId, FollowStatus status, Pageable pageable);
     Page<Follow> findByFollowingIdAndStatus(Long followingId, FollowStatus status, Pageable pageable);
 
-    int countByFollowerId(Long memberId);
-    int countByFollowingId(Long memberId);
+    int countByFollowingIdAndStatus(Long followingId, FollowStatus status);
+    int countByFollowerIdAndStatus(Long followerId, FollowStatus status);
 
     @Query("""
         select f

--- a/src/main/java/com/example/moro/app/member/dto/ProfileResponse.java
+++ b/src/main/java/com/example/moro/app/member/dto/ProfileResponse.java
@@ -16,7 +16,7 @@ public class ProfileResponse {
     private String userName;
     private String userColorHex;
     private int colorCount;
-    private int postCount;
+    private int followerCount;
     private int followingCount;
     private boolean isCurrentUser;
     private boolean isVisible;

--- a/src/main/java/com/example/moro/app/member/service/MemberService.java
+++ b/src/main/java/com/example/moro/app/member/service/MemberService.java
@@ -116,9 +116,9 @@ public class MemberService {
 
         int colorCount = userColorMapRepository.countByMemberAndUnlockedTrue(member);
 
-        int postCount = postRepository.countByMemberId(member.getId());
+        int followerCount = followRepository.countByFollowingIdAndStatus(member.getId(), FollowStatus.ACCEPTED);
 
-        int followingCount = followRepository.countByFollowerId(member.getId());
+        int followingCount = followRepository.countByFollowerIdAndStatus(member.getId(), FollowStatus.ACCEPTED);
 
         List<UserColor> colorCodes = Collections.emptyList();
         if(isVisible) {
@@ -138,7 +138,7 @@ public class MemberService {
                 .userName(member.getUserName())
                 .userColorHex(userColorHex)
                 .colorCount(colorCount)
-                .postCount(postCount)
+                .followerCount(followerCount)
                 .followingCount(followingCount)
                 .isCurrentUser(member.getId().equals(currentUserId))
                 .isVisible(isVisible)


### PR DESCRIPTION
## 📌 이슈
- closed #28

## 🚀 구현 내용 설명
<!-- 구현 내용에 대한 간략한 설명을 작성해주세요 -->

- 기존 postCount를 빼고 팔로워 수를 추가
- 승인된 팔로우 관계의 팔로잉 수와 팔로워 수를 반환하도록 수정