### PR TITLE
fix: followingStatus 필드를 추가하여 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/moro/app/member/dto/ProfileResponse.java
+++ b/src/main/java/com/example/moro/app/member/dto/ProfileResponse.java
@@ -15,6 +15,7 @@ public class ProfileResponse {
     private Long userId;
     private String userName;
     private String userColorHex;
+    private String followingStatus;
     private int colorCount;
     private int followerCount;
     private int followingCount;

--- a/src/main/java/com/example/moro/app/member/service/MemberService.java
+++ b/src/main/java/com/example/moro/app/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.moro.app.member.service;
 import com.example.moro.app.colormap.entity.ColorMap;
 import com.example.moro.app.colormap.repository.ColorMapRepository;
 import com.example.moro.app.colormap.repository.UserColorMapRepository;
+import com.example.moro.app.follow.entity.Follow;
 import com.example.moro.app.follow.entity.FollowStatus;
 import com.example.moro.app.follow.repository.FollowRepository;
 import com.example.moro.app.member.dto.*;
@@ -114,6 +115,12 @@ public class MemberService {
                     .orElse(false);
         }
 
+        String followingStatus = isCurrentUser ? "NONE" :
+                                followRepository
+                                .findByFollowerIdAndFollowingId(currentUserId, targetUserId)
+                                .map(f -> f.getStatus().name())
+                                .orElse("NONE");
+
         int colorCount = userColorMapRepository.countByMemberAndUnlockedTrue(member);
 
         int followerCount = followRepository.countByFollowingIdAndStatus(member.getId(), FollowStatus.ACCEPTED);
@@ -137,6 +144,7 @@ public class MemberService {
                 .userId(member.getId())
                 .userName(member.getUserName())
                 .userColorHex(userColorHex)
+                .followingStatus(followingStatus)
                 .colorCount(colorCount)
                 .followerCount(followerCount)
                 .followingCount(followingCount)


### PR DESCRIPTION
## 📌 이슈
- closed #84 

## 🚀 구현 내용 설명
<!-- 구현 내용에 대한 간략한 설명을 작성해주세요 -->
- 기존 필드에서 followingStatus를 추가하여 반환하도록 수정하였습니다.
- follwoing Status 설명
> 본인 프로필과 팔로잉 하고 있지 않은 유저 프로필을 조회할 경우"NONE"
> 팔로잉하고 있는 프로필을 조회했을 때는 "ACCEPTED"
> 팔로잉 요청이 수락되지 않은 유저의 프로필에서는 "PENDING"