### PR TITLE
fix: mappostummary에 latlng 필드 추가

### DIFF
--- a/src/main/java/com/example/moro/app/map/dto/MapPostSummary.java
+++ b/src/main/java/com/example/moro/app/map/dto/MapPostSummary.java
@@ -7,4 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MapPostSummary {
     private Long postId;
+    private Double lat;
+    private Double lng;
 }

--- a/src/main/java/com/example/moro/app/map/service/MapService.java
+++ b/src/main/java/com/example/moro/app/map/service/MapService.java
@@ -48,7 +48,7 @@ public class MapService {
                         box.getMaxLng()
                 )
                 .stream()
-                .map(post -> new MapPostSummary(post.getId()))
+                .map(post -> new MapPostSummary(post.getId(),post.getLat(),post.getLng()))
                 .toList();
     }
 


### PR DESCRIPTION
## 📌 이슈
- closed #100

## 🚀 구현 내용 설명
<!-- 구현 내용에 대한 간략한 설명을 작성해주세요 -->
- 지도에 게시물의 위경도값을 포함하하여 반환하도록 수정하였습니다.

## 📸 테스트 방법 (스크린샷 선택) 
<img width="1411" height="1344" alt="스크린샷 2026-01-21 232015" src="https://github.com/user-attachments/assets/870fc919-bee1-458a-82d8-cd8b0e2e7025" />


<img width="1197" height="1373" alt="스크린샷 2026-01-21 231539" src="https://github.com/user-attachments/assets/f5d5356b-0d13-408a-8ebb-51b1285e012f" />


