### PR TITLE
feat: 본인 프로필 조회용 api

### DIFF
--- a/src/main/java/com/example/moro/app/member/controller/MemberController.java
+++ b/src/main/java/com/example/moro/app/member/controller/MemberController.java
@@ -110,6 +110,18 @@ public class MemberController {
         return ApiResponseTemplate.success(SuccessCode.RESOURCE_RETRIEVED, response);
 
     }
+    @Operation(summary = "본인 프로필 조회 (색상 목록 포함)", description = "특정 유저의 프로필 정보(대표 색상 6가지 목록 포함)를 조회합니다.")
+    @GetMapping("/me/profile")
+    public ResponseEntity<ApiResponseTemplate<ProfileResponse>> getUserProfile() {
+
+        Member currentUser = securityUtil.getCurrentMember();
+        Long currentUserId = currentUser.getId();
+
+        ProfileResponse response = memberService.getProfile(currentUserId, currentUserId);
+
+        return ApiResponseTemplate.success(SuccessCode.RESOURCE_RETRIEVED, response);
+
+    }
 
     @Operation(summary = "프로필 수정", description = "나의 프로필 정보(이름, 프로필 배경색)를 수정합니다.")
     @PutMapping("/me/profile")


### PR DESCRIPTION
## 📌 이슈
- closed #110

## 🚀 구현 내용 설명
<!-- 구현 내용에 대한 간략한 설명을 작성해주세요 -->
- 인증된 토큰을 기반으로한 본인 프로필을 조회용 api를 별도로 분리
- 기존 프로필 조회 api와 구조를 똑같이 가져감
<img width="1694" height="1270" alt="image" src="https://github.com/user-attachments/assets/5134de7e-2148-4955-943b-551d7f6e0c07" />
