### PR TITLE
fix: 본인 프로필 피드 조회시 전체보기(user_colors)는 업로드 최신순으로 반환

### DIFF
--- a/src/main/java/com/example/moro/app/member/controller/MemberController.java
+++ b/src/main/java/com/example/moro/app/member/controller/MemberController.java
@@ -148,7 +148,8 @@ public class MemberController {
     ) {
         Pageable pageable = PageRequest.of(page, size);
 
-        UserFeedListResponse response = memberService.getProfileFeed(userId, viewType, colorId, pageable);
+        Member me = securityUtil.getCurrentMember();
+        UserFeedListResponse response = memberService.getProfileFeed(me.getId(), userId, viewType, colorId, pageable);
         return ApiResponseTemplate.success(SuccessCode.RESOURCE_RETRIEVED, response);
     }
 

--- a/src/main/java/com/example/moro/app/member/service/MemberService.java
+++ b/src/main/java/com/example/moro/app/member/service/MemberService.java
@@ -204,9 +204,13 @@ public class MemberService {
     }
 
 
-    public UserFeedListResponse getProfileFeed(Long targetUserId, ProfileFeedType type, Integer colorId, Pageable pageable) {
+    public UserFeedListResponse getProfileFeed(Long currentUserId, Long targetUserId, ProfileFeedType type, Integer colorId, Pageable pageable) {
+
         Member member = memberRepository.findById(targetUserId)
                 .orElseThrow(() -> new BusinessException( ErrorCode.RESOURCE_NOT_FOUND, "해당 회원이 존재하지 않습니다."));
+
+        boolean isMyProfile = currentUserId.equals(targetUserId);
+
 
         Page<Post> postPage;
 
@@ -228,6 +232,12 @@ public class MemberService {
             }
 
             case USER_COLORS -> {
+
+                if (isMyProfile) {
+                    postPage = postRepository.findByMemberOrderByCreatedAtDesc(member, pageable);
+                    break;
+                }
+
                 List<Integer> representativeColorIds =
                         userColorMapRepository
                                 .findByMemberAndIsRepresentativeTrue(member)


### PR DESCRIPTION


## 🚀 구현 내용 설명
<!-- 구현 내용에 대한 간략한 설명을 작성해주세요 -->
<img width="1160" height="125" alt="image" src="https://github.com/user-attachments/assets/6fba0901-c57a-48db-9fd2-2ebd6f7f3709" />

- 기존 전체보기가 타 유저 프로필에서의 all을 조회하는것처럼 컬러 팔레트의 조합을 고려한 반환인 줄 알았으나 qa상 업로드 최신순 게시물을 반환 해야 함을  확인하여 이를 반영하였습니다. 


